### PR TITLE
For gdbauth/sodium package

### DIFF
--- a/dockerfiles/scripts/install_sysdeps.sh
+++ b/dockerfiles/scripts/install_sysdeps.sh
@@ -13,10 +13,10 @@ declare -A pkgs_to_install
 pkgs_to_install["r-ver"]="git qpdf unattended-upgrades"
 
 # Deps for rstudio
-pkgs_to_install["rstudio"]="libxml2-dev pandoc libicu-dev libgit2-dev zlib1g-dev libfontconfig1-dev libfreetype6-dev libjpeg-dev libpng-dev libtiff-dev libfribidi-dev libharfbuzz-dev imagemagick libmagick++-dev unixodbc-dev curl qpdf unattended-upgrades ssh libmysqlclient-dev"
+pkgs_to_install["rstudio"]="libxml2-dev pandoc libicu-dev libgit2-dev zlib1g-dev libfontconfig1-dev libfreetype6-dev libjpeg-dev libpng-dev libtiff-dev libfribidi-dev libharfbuzz-dev imagemagick libmagick++-dev unixodbc-dev curl qpdf unattended-upgrades ssh libmysqlclient-dev libsodium-dev"
 
 # Deps for rstudio-local
-pkgs_to_install["rstudio-local"]="libxml2-dev pandoc libicu-dev libgit2-dev zlib1g-dev libfontconfig1-dev libfreetype6-dev libjpeg-dev libpng-dev libtiff-dev libfribidi-dev libharfbuzz-dev imagemagick libmagick++-dev unixodbc-dev curl qpdf unattended-upgrades less ssh libmysqlclient-dev"
+pkgs_to_install["rstudio-local"]="libxml2-dev pandoc libicu-dev libgit2-dev zlib1g-dev libfontconfig1-dev libfreetype6-dev libjpeg-dev libpng-dev libtiff-dev libfribidi-dev libharfbuzz-dev imagemagick libmagick++-dev unixodbc-dev curl qpdf unattended-upgrades less ssh libmysqlclient-dev libsodium-dev"
 
 # Deps for tidyverse
 pkgs_to_install["tidyverse"]="pandoc libjpeg-dev libtiff-dev libfribidi-dev libharfbuzz-dev imagemagick libmagick++-dev curl qpdf unattended-upgrades"


### PR DESCRIPTION
```
Configuration failed because libsodium was not found. Try installing:
 * deb: libsodium-dev (Debian, Ubuntu, etc)
 * rpm: libsodium-devel (Fedora, EPEL)
 * csw: libsodium_dev (Solaris)
 * brew: libsodium (OSX)
```
```
-------------------------- [ERROR MESSAGE] ---------------------------
<stdin>:1:10: fatal error: sodium.h: No such file or directory
compilation terminated.
--------------------------------------------------------------------
ERROR: configuration failed for package ‘sodium’
* removing ‘/usr/local/lib/R/site-library/sodium’
cat: gdbauth.out: No such file or directory
```