### PR TITLE
Install xdg-utils instead of xdg-open

### DIFF
--- a/dockerfiles/scripts/install_sysdeps.sh
+++ b/dockerfiles/scripts/install_sysdeps.sh
@@ -13,7 +13,7 @@ declare -A pkgs_to_install
 pkgs_to_install["rstudio"]="libxml2-dev pandoc libicu-dev libgit2-dev zlib1g-dev libfontconfig1-dev libfreetype6-dev libjpeg-dev libpng-dev libtiff-dev libfribidi-dev libharfbuzz-dev imagemagick libmagick++-dev unixodbc-dev curl qpdf unattended-upgrades ssh libmysqlclient-dev libsodium-dev default-jdk cmake jags"
 
 # Deps for rstudio-local
-pkgs_to_install["rstudio-local"]="libxml2-dev pandoc libicu-dev libgit2-dev zlib1g-dev libfontconfig1-dev libfreetype6-dev libjpeg-dev libpng-dev libtiff-dev libfribidi-dev libharfbuzz-dev imagemagick libmagick++-dev unixodbc-dev curl qpdf unattended-upgrades less ssh libmysqlclient-dev libsodium-dev default-jdk vim cmake xdg-open"
+pkgs_to_install["rstudio-local"]="libxml2-dev pandoc libicu-dev libgit2-dev zlib1g-dev libfontconfig1-dev libfreetype6-dev libjpeg-dev libpng-dev libtiff-dev libfribidi-dev libharfbuzz-dev imagemagick libmagick++-dev unixodbc-dev curl qpdf unattended-upgrades less ssh libmysqlclient-dev libsodium-dev default-jdk vim cmake xdg-utils"
 
 # Set env vars
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
My apologies, xdg-open installation should come from  `xdg-utils`, see https://command-not-found.com/xdg-open

Currently xdg-open is causing the pipeline failing. https://github.com/insightsengineering/ci-images/actions/runs/2111175276
https://github.com/insightsengineering/ci-images/runs/5874915547?check_suite_focus=true

