### PR TITLE
NEST releases on local images

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,13 +21,14 @@ on:
         description: R Version
         required: true
         type: choice
-        default: "4.2.0"
+        default: "4.2.1"
         options:
           - "4.1.0"
           - "4.1.1"
           - "4.1.2"
           - "4.1.3"
           - "4.2.0"
+          - "4.2.1"
       bioc_version:
         description: BioConductor Release
         required: true

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix: 
         image:
-          - r: '4.2.0'
+          - r: '4.2.1'
             bioc: '3.15'
             distro: rstudio-local
-          - r: '4.2.0'
+          - r: '4.2.1'
             bioc: '3.15'
             distro: rstudio
 

--- a/scripts/install_gh_pkgs.R
+++ b/scripts/install_gh_pkgs.R
@@ -5,6 +5,45 @@
 args <- commandArgs(trailing = TRUE)
 distribution <- args[1]
 
+# NEST packages to be installed
+nest_release_date <- "2022_06_09" # Can be *release to get latest releases
+ie_nest_packages <- c(
+  "scda.2021",
+  "scda.2022",
+  "formatters",
+  "ggplot2.utils",
+  "hermes",
+  "teal.logger",
+  "scda",
+  "goshawk",
+  "teal.data",
+  "teal.reporter",
+  "teal.widgets",
+  "tern",
+  "teal.code",
+  "teal.slice",
+  "osprey",
+  "tern.mmrm",
+  "teal.transform",
+  "teal",
+  "teal.goshawk",
+  "teal.modules.clinical",
+  "teal.modules.general",
+  "teal.modules.hermes",
+  "teal.osprey"
+)
+roche_nest_packages <- c(
+  "rtables"
+)
+all_nest_packages <- c(
+  paste0(
+    "Roche/", roche_nest_packages, "@", nest_release_date
+  ),
+  paste0(
+    "insightsengineering/", ie_nest_packages, "@", nest_release_date
+  )
+)
+
 # Packages to install
 gh_pkgs <- list(
   rstudio = c(
@@ -17,7 +56,8 @@ gh_pkgs <- list(
     "tlverse/sl3@v1.4.4",
     "r-lib/styler",
     "insightsengineering/nesttemplate",
-    "openpharma/staged.dependencies@*release"
+    "openpharma/staged.dependencies@*release",
+    all_nest_packages
   )
 )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

### Description

Add NEST releases to `rstudio-local` images so folks can use NEST out of the box.