### PR TITLE
Release creation on schedule bugfix

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -6,8 +6,32 @@ on:
   workflow_dispatch:
 
 jobs:
+  create-release:
+    name: Create release 🌟
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate release body 📜
+        id: release-body
+        run: |
+          printf "Release $(date +"%Y.%m.%d")\n\n"\
+          "You may view the artifacts in this release for more information "\
+          "about the images that were published." > RELEASE_BODY.txt
+          echo "release-tag=$(date +"%Y.%m.%d")" >> $GITHUB_OUTPUT
+
+      - name: Create release 🌟
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: RELEASE_BODY.txt
+          token: ${{ secrets.REPO_GITHUB_TOKEN }}
+          generate_release_notes: true
+          tag_name: ${{ steps.release-body.outputs.release-tag }}
+
+    outputs:
+      release_tag: ${{ steps.release-body.outputs.release-tag }}
+
   build:
     name: Build & Deploy 🚀
+    needs: create-release
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -52,22 +76,6 @@ jobs:
         with:
           ref: main
 
-      - name: Generate release body 📜
-        id: release-body
-        run: |
-          printf "Release $(date +"%Y.%m.%d")\n\n"\
-          "You may view the artifacts in this release for more information "\
-          "about the images that were published." > RELEASE_BODY.txt
-          echo "release-tag=$(date +"%Y.%m.%d")" >> $GITHUB_OUTPUT
-
-      - name: Create release 🌟
-        uses: softprops/action-gh-release@v1
-        with:
-          body_path: RELEASE_BODY.txt
-          token: ${{ secrets.REPO_GITHUB_TOKEN }}
-          generate_release_notes: true
-          tag_name: ${{ steps.release-body.outputs.release-tag }}
-
       - name: Trigger all builds ▶️
         uses: peter-evans/repository-dispatch@v2
         with:
@@ -81,5 +89,5 @@ jobs:
               "bioc_version": "${{ matrix.image.bioc }}",
               "tag": "",
               "tag_latest": "true",
-              "release_tag": "${{ steps.release-body.outputs.release-tag }}"
+              "release_tag": "${{ needs.create-release.outputs.release_tag }}"
             }


### PR DESCRIPTION
Fix a bug in which the release creation happens as part of `build` job.

The release should be created before `build` job.