### PR TITLE
Free GitHub Actions runner disk space

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -127,6 +127,16 @@ jobs:
 
     # Build steps
     steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: false
+
       - name: Checkout repository 💳
         uses: actions/checkout@v3
 


### PR DESCRIPTION
Freeing GitHub Actions runner disk space is required to address issues like [this one](https://github.com/insightsengineering/ci-images/actions/runs/4817186190/jobs/8580452693).