### PR TITLE
Install roxylint and roxytypes

### DIFF
--- a/scripts/install_gh_pkgs.R
+++ b/scripts/install_gh_pkgs.R
@@ -10,7 +10,9 @@ distribution <- args[1]
 shared_pkgs <- c(
   "tlverse/sl3@v1.4.4",
   "insightsengineering/nesttemplate",
-  "openpharma/staged.dependencies@*release"
+  "openpharma/staged.dependencies@*release",
+  "openpharma/roxylint",
+  "openpharma/roxytypes"
 )
 
 gh_pkgs <- list(


### PR DESCRIPTION
As they're used by some of the packages for roxygen tags.
