### PR TITLE
Assert correctness of ci images

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -184,7 +184,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.REPO_GITHUB_TOKEN }}
 
       - name: Set build variables 📐
         id: build_vars

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base 🧶
-        uses: github/super-linter/slim@v5
+        uses: super-linter/super-linter/slim@v5
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,5 +49,7 @@ RUN ./install_cran_pkgs.R ${DISTRIBUTION} && \
         install_other_pkgs.R \
         install_pip_pkgs.py
 
+RUN pdflatex --version
+
 # Run RStudio
 CMD ["/init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,22 +39,22 @@ RUN java -version
 RUN python3 --version
 
 # Install R packages
-# RUN ./install_cran_pkgs.R ${DISTRIBUTION} && \
-#     ./install_bioc.R ${BIOC_VERSION} && \
-#     ./install_bioc_pkgs.R ${DISTRIBUTION} && \
-#     ./install_gh_pkgs.R ${DISTRIBUTION} && \
-#     ./install_other_pkgs.R ${DISTRIBUTION} && \
-#     ./install_pip_pkgs.py ${DISTRIBUTION} && \
-#     rm -f install_sysdeps.sh \
-#         install_cran_pkgs.R \
-#         install_bioc.R \
-#         install_bioc_pkgs.R \
-#         install_gh_pkgs.R \
-#         install_other_pkgs.R \
-#         install_pip_pkgs.py
+RUN ./install_cran_pkgs.R ${DISTRIBUTION} && \
+    ./install_bioc.R ${BIOC_VERSION} && \
+    ./install_bioc_pkgs.R ${DISTRIBUTION} && \
+    ./install_gh_pkgs.R ${DISTRIBUTION} && \
+    ./install_other_pkgs.R ${DISTRIBUTION} && \
+    ./install_pip_pkgs.py ${DISTRIBUTION} && \
+    rm -f install_sysdeps.sh \
+        install_cran_pkgs.R \
+        install_bioc.R \
+        install_bioc_pkgs.R \
+        install_gh_pkgs.R \
+        install_other_pkgs.R \
+        install_pip_pkgs.py
 
 # Prevent pushing of the image without pdflatex installed.
-# RUN pdflatex --version
+RUN pdflatex --version
 
 # Run RStudio
 CMD ["/init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN ./install_sysdeps.sh ${DISTRIBUTION}
 
 RUN R --version
 RUN java -version
+RUN python3 --version
 
 # Install R packages
 # RUN ./install_cran_pkgs.R ${DISTRIBUTION} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ RUN ./install_cran_pkgs.R ${DISTRIBUTION} && \
         install_other_pkgs.R \
         install_pip_pkgs.py
 
+# Prevent pushing of the image without pdflatex installed.
 RUN pdflatex --version
 
 # Run RStudio

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,9 @@ COPY --chmod=0755 [\
 # Install sysdeps
 RUN ./install_sysdeps.sh ${DISTRIBUTION}
 
-RUN R --version
-RUN java -version
-RUN python3 --version
+RUN R --version && \
+    java -version && \
+    python3 --version
 
 # Install R packages
 RUN ./install_cran_pkgs.R ${DISTRIBUTION} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,23 +34,26 @@ COPY --chmod=0755 [\
 # Install sysdeps
 RUN ./install_sysdeps.sh ${DISTRIBUTION}
 
+RUN R --version
+RUN java -version
+
 # Install R packages
-RUN ./install_cran_pkgs.R ${DISTRIBUTION} && \
-    ./install_bioc.R ${BIOC_VERSION} && \
-    ./install_bioc_pkgs.R ${DISTRIBUTION} && \
-    ./install_gh_pkgs.R ${DISTRIBUTION} && \
-    ./install_other_pkgs.R ${DISTRIBUTION} && \
-    ./install_pip_pkgs.py ${DISTRIBUTION} && \
-    rm -f install_sysdeps.sh \
-        install_cran_pkgs.R \
-        install_bioc.R \
-        install_bioc_pkgs.R \
-        install_gh_pkgs.R \
-        install_other_pkgs.R \
-        install_pip_pkgs.py
+# RUN ./install_cran_pkgs.R ${DISTRIBUTION} && \
+#     ./install_bioc.R ${BIOC_VERSION} && \
+#     ./install_bioc_pkgs.R ${DISTRIBUTION} && \
+#     ./install_gh_pkgs.R ${DISTRIBUTION} && \
+#     ./install_other_pkgs.R ${DISTRIBUTION} && \
+#     ./install_pip_pkgs.py ${DISTRIBUTION} && \
+#     rm -f install_sysdeps.sh \
+#         install_cran_pkgs.R \
+#         install_bioc.R \
+#         install_bioc_pkgs.R \
+#         install_gh_pkgs.R \
+#         install_other_pkgs.R \
+#         install_pip_pkgs.py
 
 # Prevent pushing of the image without pdflatex installed.
-RUN pdflatex --version
+# RUN pdflatex --version
 
 # Run RStudio
 CMD ["/init"]

--- a/scripts/install_cran_pkgs.R
+++ b/scripts/install_cran_pkgs.R
@@ -280,7 +280,6 @@ mv ~/.TinyTeX /opt/TinyTeX
 /opt/TinyTeX/bin/*/tlmgr path add
 tlmgr install makeindex metafont mfware inconsolata tex ae parskip listings xcolor epstopdf-pkg pdftexcmds kvoptions texlive-scripts grfext soul todonotes koma-script subfig bookmark babel-english caption
 tlmgr path add
-exit 1
 '
   # nolint end
   exit_status <- system(tinytex_installer)

--- a/scripts/install_cran_pkgs.R
+++ b/scripts/install_cran_pkgs.R
@@ -286,6 +286,8 @@ tlmgr path add
   if ("status" %in% names(attributes(exit_status))) {
     cat("TinyTex installer exited with code =", attr(exit_status, "status"), "\n")
     quit(status = attr(exit_status, "status"))
+  } else {
+    cat("TinyTex installer output:\n", exit_status, "\n")
   }
   tinytex::r_texmf()
   permission_update <- '
@@ -299,6 +301,8 @@ echo "PATH=${PATH}" >> ${R_HOME}/etc/Renviron
   if ("status" %in% names(attributes(exit_status))) {
     cat("TinyTex permission update exited with code =", attr(exit_status, "status"), "\n")
     quit(status = attr(exit_status, "status"))
+  } else {
+    cat("TinyTex permission update output:\n", exit_status, "\n")
   }
 }
 

--- a/scripts/install_cran_pkgs.R
+++ b/scripts/install_cran_pkgs.R
@@ -282,12 +282,10 @@ tlmgr install makeindex metafont mfware inconsolata tex ae parskip listings xcol
 tlmgr path add
 '
   # nolint end
-  exit_status <- system2("bash", args = c("-c", shQuote(tinytex_installer)), stdout = TRUE, stderr = TRUE)
-  if ("status" %in% names(attributes(exit_status))) {
-    cat("TinyTex installer exited with code =", attr(exit_status, "status"), "\n")
-    quit(status = attr(exit_status, "status"))
-  } else {
-    cat("TinyTex installer output:\n", exit_status, "\n")
+  exit_status <- system(tinytex_installer)
+  cat("TinyTex installer exited with code =", exit_status, "\n")
+  if (exit_status != 0) {
+    quit(status = exit_status)
   }
   tinytex::r_texmf()
   permission_update <- '
@@ -297,12 +295,10 @@ chmod -R g+wx /opt/TinyTeX/bin
 export PATH=/opt/TinyTeX/bin/x86_64-linux:${PATH}
 echo "PATH=${PATH}" >> ${R_HOME}/etc/Renviron
 '
-  exit_status <- system2("bash", args = c("-c", shQuote(permission_update)), stdout = TRUE, stderr = TRUE)
-  if ("status" %in% names(attributes(exit_status))) {
-    cat("TinyTex permission update exited with code =", attr(exit_status, "status"), "\n")
-    quit(status = attr(exit_status, "status"))
-  } else {
-    cat("TinyTex permission update output:\n", exit_status, "\n")
+  exit_status <- system(permission_update)
+  cat("TinyTex installer exited with code =", exit_status, "\n")
+  if (exit_status != 0) {
+    quit(status = exit_status)
   }
 }
 

--- a/scripts/install_cran_pkgs.R
+++ b/scripts/install_cran_pkgs.R
@@ -282,7 +282,11 @@ tlmgr install makeindex metafont mfware inconsolata tex ae parskip listings xcol
 tlmgr path add
 '
   # nolint end
-  system(tinytex_installer)
+  exit_code <- system2("bash", args = c("-c", shQuote(tinytex_installer)), stdout = FALSE, stderr = FALSE)
+  cat("TinyTex installation exit code:", exit_code, "\n")
+  if (exit_code != 0) {
+    quit(status = exit_code, save = "no")
+  }
   tinytex::r_texmf()
   permission_update <- '
 chown -R root:staff /opt/TinyTeX
@@ -291,7 +295,11 @@ chmod -R g+wx /opt/TinyTeX/bin
 export PATH=/opt/TinyTeX/bin/x86_64-linux:${PATH}
 echo "PATH=${PATH}" >> ${R_HOME}/etc/Renviron
 '
-  system(permission_update)
+  exit_code <- system2("bash", args = c("-c", shQuote(permission_update)), stdout = FALSE, stderr = FALSE)
+  cat("TinyTex permission update exit code:", exit_code, "\n")
+  if (exit_code != 0) {
+    quit(status = exit_code, save = "no")
+  }
 }
 
 # Update all packages

--- a/scripts/install_cran_pkgs.R
+++ b/scripts/install_cran_pkgs.R
@@ -296,7 +296,7 @@ export PATH=/opt/TinyTeX/bin/x86_64-linux:${PATH}
 echo "PATH=${PATH}" >> ${R_HOME}/etc/Renviron
 '
   exit_status <- system(permission_update)
-  cat("TinyTex installer exited with code =", exit_status, "\n")
+  cat("TinyTex permission update exited with code =", exit_status, "\n")
   if (exit_status != 0) {
     quit(status = exit_status)
   }

--- a/scripts/install_cran_pkgs.R
+++ b/scripts/install_cran_pkgs.R
@@ -283,7 +283,7 @@ tlmgr path add
 '
   # nolint end
   exit_status <- system(tinytex_installer)
-  cat("TinyTex installer exited with code =", exit_status, "\n")
+  cat("TinyTeX installer exited with code =", exit_status, "\n")
   if (exit_status != 0) {
     quit(status = exit_status)
   }
@@ -296,7 +296,7 @@ export PATH=/opt/TinyTeX/bin/x86_64-linux:${PATH}
 echo "PATH=${PATH}" >> ${R_HOME}/etc/Renviron
 '
   exit_status <- system(permission_update)
-  cat("TinyTex permission update exited with code =", exit_status, "\n")
+  cat("TinyTeX permission update exited with code =", exit_status, "\n")
   if (exit_status != 0) {
     quit(status = exit_status)
   }

--- a/scripts/install_cran_pkgs.R
+++ b/scripts/install_cran_pkgs.R
@@ -282,10 +282,10 @@ tlmgr install makeindex metafont mfware inconsolata tex ae parskip listings xcol
 tlmgr path add
 '
   # nolint end
-  exit_code <- system2("bash", args = c("-c", shQuote(tinytex_installer)), stdout = FALSE, stderr = FALSE)
-  cat("TinyTex installation exit code:", exit_code, "\n")
-  if (exit_code != 0) {
-    quit(status = exit_code, save = "no")
+  exit_status <- system2("bash", args = c("-c", shQuote(tinytex_installer)), stdout = TRUE, stderr = TRUE)
+  if ("status" %in% names(attributes(exit_status))) {
+    cat("TinyTex installer exited with code =", attr(exit_status, "status"), "\n")
+    quit(status = attr(exit_status, "status"))
   }
   tinytex::r_texmf()
   permission_update <- '
@@ -295,10 +295,10 @@ chmod -R g+wx /opt/TinyTeX/bin
 export PATH=/opt/TinyTeX/bin/x86_64-linux:${PATH}
 echo "PATH=${PATH}" >> ${R_HOME}/etc/Renviron
 '
-  exit_code <- system2("bash", args = c("-c", shQuote(permission_update)), stdout = FALSE, stderr = FALSE)
-  cat("TinyTex permission update exit code:", exit_code, "\n")
-  if (exit_code != 0) {
-    quit(status = exit_code, save = "no")
+  exit_status <- system2("bash", args = c("-c", shQuote(permission_update)), stdout = TRUE, stderr = TRUE)
+  if ("status" %in% names(attributes(exit_status))) {
+    cat("TinyTex permission update exited with code =", attr(exit_status, "status"), "\n")
+    quit(status = attr(exit_status, "status"))
   }
 }
 

--- a/scripts/install_cran_pkgs.R
+++ b/scripts/install_cran_pkgs.R
@@ -280,6 +280,7 @@ mv ~/.TinyTeX /opt/TinyTeX
 /opt/TinyTeX/bin/*/tlmgr path add
 tlmgr install makeindex metafont mfware inconsolata tex ae parskip listings xcolor epstopdf-pkg pdftexcmds kvoptions texlive-scripts grfext soul todonotes koma-script subfig bookmark babel-english caption
 tlmgr path add
+exit 1
 '
   # nolint end
   exit_status <- system(tinytex_installer)


### PR DESCRIPTION
Closes https://github.com/insightsengineering/idr-tasks/issues/707

Example failure, when we add `exit 1` after TinyTex installation can be seen [here](https://github.com/insightsengineering/ci-images/actions/runs/7116656353/job/19375587491).