### PR TITLE
Use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -184,7 +184,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.REPO_GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set build variables 📐
         id: build_vars


### PR DESCRIPTION
The building of `ci-images` fails with this error:
```
ERROR: failed to solve: failed to push ghcr.io/insightsengineering/debian-gcc-devel:2023.12.07: unexpected status from POST request to https://ghcr.io/v2/insightsengineering/debian-gcc-devel/blobs/uploads/: 403 Forbidden
```

I think it's because of [this change](https://github.com/insightsengineering/ci-images/pull/90/files#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54R187).

Maybe we should revert it?