### PR TITLE
Upgrade R and BioC and install libarchive for shinylive

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,7 +38,7 @@ on:
         description: R Version
         required: true
         type: choice
-        default: "4.3.3"
+        default: "4.4.0"
         options:
           - "4.1.0"
           - "4.1.1"
@@ -51,17 +51,18 @@ on:
           - "4.3.1"
           - "4.3.2"
           - "4.3.3"
+          - "4.4.0"
           - "latest"
       latest_r_version:
         description: "R Version to be aliased as the 'latest' tag"
         required: false
         type: string
-        default: "4.3.3"
+        default: "4.4.0"
       bioc_version:
         description: BioConductor Release
         required: true
         type: choice
-        default: "3.18"
+        default: "3.19"
         options:
           - "3.13"
           - "3.14"
@@ -69,12 +70,13 @@ on:
           - "3.16"
           - "3.17"
           - "3.18"
+          - "3.19"
           - "devel"
       latest_bioc_version:
         description: "BioC Version to be aliased as the 'latest' tag"
         required: false
         type: string
-        default: "3.18"
+        default: "3.19"
       tag:
         description: |
           Custom Image Tag/Version. Defaults to current date in the `YYYY.MM.DD` format if unspecified.

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -36,12 +36,12 @@ jobs:
     strategy:
       matrix:
         image:
-          - distro_tag: '4.3.3'
-            bioc: '3.18'
+          - distro_tag: '4.4.0'
+            bioc: '3.19'
             distro: rstudio-local
             origin: rocker
-          - distro_tag: '4.3.3'
-            bioc: '3.18'
+          - distro_tag: '4.4.0'
+            bioc: '3.19'
             distro: rstudio
             origin: rocker
           - distro_tag: 'latest'
@@ -61,11 +61,11 @@ jobs:
             distro: fedora-gcc-devel
             origin: rhub
           - distro_tag: 'latest'
-            bioc: '3.18'
+            bioc: '3.19'
             distro: debian-gcc-patched
             origin: rhub
           - distro_tag: 'latest'
-            bioc: '3.18'
+            bioc: '3.19'
             distro: debian-gcc-release
             origin: rhub
 
@@ -87,8 +87,8 @@ jobs:
               "distribution": "${{ matrix.image.distro }}",
               "r_version": "${{ matrix.image.distro_tag }}",
               "bioc_version": "${{ matrix.image.bioc }}",
-              "latest_r_version": "4.3.3",
-              "latest_bioc_version": "3.18",
+              "latest_r_version": "4.4.0",
+              "latest_bioc_version": "3.19",
               "tag": "",
               "tag_latest": "true",
               "release_tag": "${{ needs.create-release.outputs.release_tag }}"

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       matrix:
         image:
-          - r: '4.3.3'
-            bioc: '3.18'
-            distro: rstudio-local
+          - r: '4.4.0'
+            bioc: '3.19'
+            distro: rstudio
     steps:
       - name: Log in to the Container registry 🗝
         uses: docker/login-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # Build arguments
 ARG ORIGIN=rocker
 ARG ORIGIN_DISTRIBUTION=rstudio
-ARG R_VERSION=4.3.3
+ARG R_VERSION=4.4.0
 
 # Fetch base image
 FROM ${ORIGIN}/${ORIGIN_DISTRIBUTION}:${R_VERSION}
 
 # Reset args in build context
 ARG DISTRIBUTION=rstudio-local
-ARG BIOC_VERSION=3.18
+ARG BIOC_VERSION=3.19
 
 # Set image metadata
 LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \

--- a/scripts/install_cran_pkgs.R
+++ b/scripts/install_cran_pkgs.R
@@ -191,6 +191,7 @@ shared_pkgs <- c(
   "shinyTree",
   "shinyvalidate",
   "shinyWidgets",
+  "shinylive",
   "simsurv",
   "sparkline",
   "spelling",

--- a/scripts/install_sysdeps.sh
+++ b/scripts/install_sysdeps.sh
@@ -49,6 +49,7 @@ libv8-dev \
 libpq-dev \
 tidy \
 libglpk-dev \
+libarchive-dev \
 "
 
 # Shared deps for fedora
@@ -92,6 +93,7 @@ udunits2-devel \
 v8-devel \
 tidy \
 glpk-devel \
+libarchive-devel \
 "
 
 # Deps specific on the rstudio image


### PR DESCRIPTION
Upgrades R to 4.4.0 and BioC to 3.19 for latest. Also installs `libarchive` as a sysdep and `shinylive` as an additional R package.