### PR TITLE
Update base Fedora images

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -31,7 +31,8 @@ on:
           - gcc13
           - gcc14
       r_version:
-        description: R Version
+        description: |
+          R version (also used as a tag to pull the origin image).
         required: true
         type: choice
         default: "4.4.0"
@@ -50,7 +51,9 @@ on:
           - "4.4.0"
           - "latest"
       latest_r_version:
-        description: "R Version to be aliased as the 'latest' tag"
+        description: |
+          R Version to be aliased as the 'latest' tag".
+          (Only relevant for rocker images).
         required: false
         type: string
         default: "4.4.0"
@@ -69,7 +72,9 @@ on:
           - "3.19"
           - "devel"
       latest_bioc_version:
-        description: "BioC Version to be aliased as the 'latest' tag"
+        description: |
+          BioC Version to be aliased as the 'latest' tag".
+          (Only relevant for rocker images).
         required: false
         type: string
         default: "3.19"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,7 +21,7 @@ on:
           - rocker
           - rhub
       distribution:
-        description: Rocker/RHub Distro Name. Eg. rstudio or gcc13
+        description: Rocker/RHub Distro Name.
         required: true
         type: choice
         default: rstudio
@@ -32,7 +32,7 @@ on:
           - gcc14
       r_version:
         description: |
-          R version (also used as a tag to pull the origin image).
+          R version (also used as the tag to pull the origin image).
         required: true
         type: choice
         default: "4.4.0"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -249,7 +249,7 @@ jobs:
         with:
           context: ./
           file: Dockerfile
-          push: 'false'
+          push: ${{ steps.build_vars.outputs.DOCKER_PUSH }}
           tags: ${{ steps.build_vars.outputs.FULL_NAMES }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -34,6 +34,7 @@ on:
           - fedora-gcc-devel
           - debian-gcc-patched
           - debian-gcc-release
+          - gcc13
       r_version:
         description: R Version
         required: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -253,7 +253,7 @@ jobs:
         with:
           context: ./
           file: Dockerfile
-          push: ${{ steps.build_vars.outputs.DOCKER_PUSH }}
+          push: 'false'
           tags: ${{ steps.build_vars.outputs.FULL_NAMES }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,6 +35,7 @@ on:
           - debian-gcc-patched
           - debian-gcc-release
           - gcc13
+          - gcc14
       r_version:
         description: R Version
         required: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -249,7 +249,7 @@ jobs:
         with:
           context: ./
           file: Dockerfile
-          push: ${{ steps.build_vars.outputs.DOCKER_PUSH }}
+          push: 'true'
           tags: ${{ steps.build_vars.outputs.FULL_NAMES }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,12 +28,6 @@ on:
         options:
           - rstudio
           - rstudio-local
-          - debian-clang-devel
-          - debian-gcc-devel
-          - fedora-clang-devel
-          - fedora-gcc-devel
-          - debian-gcc-patched
-          - debian-gcc-release
           - gcc13
           - gcc14
       r_version:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,7 +21,7 @@ on:
           - rocker
           - rhub
       distribution:
-        description: Rocker/RHub Distro Name. Eg. rstudio or fedora-gcc-devel
+        description: Rocker/RHub Distro Name. Eg. rstudio or gcc13
         required: true
         type: choice
         default: rstudio
@@ -201,7 +201,8 @@ jobs:
         run: |
           # Set Image name
           image_name="${{ needs.normalize-inputs.outputs.distribution }}_${{ needs.normalize-inputs.outputs.r_version }}_bioc_${{ needs.normalize-inputs.outputs.bioc_version }}"
-          if [[ "${{ needs.normalize-inputs.outputs.distribution }}" =~ ^debian.*|^fedora.* ]]
+          # For Fedora (gcc13 and gcc14) rhub images.
+          if [[ "${{ needs.normalize-inputs.outputs.distribution }}" =~ ^gcc.* ]]
           then {
             image_name="${{ needs.normalize-inputs.outputs.distribution }}"
           }

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -249,7 +249,7 @@ jobs:
         with:
           context: ./
           file: Dockerfile
-          push: 'true'
+          push: ${{ steps.build_vars.outputs.DOCKER_PUSH }}
           tags: ${{ steps.build_vars.outputs.FULL_NAMES }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,6 +30,11 @@ on:
           - rstudio-local
           - gcc13
           - gcc14
+          - atlas
+          - valgrind
+          - intel
+          - nosuggests
+          - mkl
       r_version:
         description: |
           R version (also used as the tag to pull the origin image).
@@ -206,8 +211,8 @@ jobs:
         run: |
           # Set Image name
           image_name="${{ needs.normalize-inputs.outputs.distribution }}_${{ needs.normalize-inputs.outputs.r_version }}_bioc_${{ needs.normalize-inputs.outputs.bioc_version }}"
-          # For Fedora (gcc13 and gcc14) rhub images.
-          if [[ "${{ needs.normalize-inputs.outputs.distribution }}" =~ ^gcc.* ]]
+          # For Fedora-based rhub images.
+          if [[ "${{ needs.normalize-inputs.outputs.distribution }}" =~ ^gcc.*|^atlas$|^valgrind$|^intel$|^nosuggests$|^mkl$ ]]
           then {
             image_name="${{ needs.normalize-inputs.outputs.distribution }}"
           }

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -36,14 +36,14 @@ jobs:
     strategy:
       matrix:
         image:
-          # - distro_tag: '4.4.0'
-          #   bioc: '3.19'
-          #   distro: rstudio-local
-          #   origin: rocker
-          # - distro_tag: '4.4.0'
-          #   bioc: '3.19'
-          #   distro: rstudio
-          #   origin: rocker
+          - distro_tag: '4.4.0'
+            bioc: '3.19'
+            distro: rstudio-local
+            origin: rocker
+          - distro_tag: '4.4.0'
+            bioc: '3.19'
+            distro: rstudio
+            origin: rocker
           - distro_tag: 'latest'
             bioc: 'devel'
             distro: gcc13

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -52,6 +52,26 @@ jobs:
             bioc: 'devel'
             distro: gcc14
             origin: rhub
+          - distro_tag: 'latest'
+            bioc: 'devel'
+            distro: atlas
+            origin: rhub
+          - distro_tag: 'latest'
+            bioc: 'devel'
+            distro: valgrind
+            origin: rhub
+          - distro_tag: 'latest'
+            bioc: 'devel'
+            distro: intel
+            origin: rhub
+          - distro_tag: 'latest'
+            bioc: 'devel'
+            distro: nosuggests
+            origin: rhub
+          - distro_tag: 'latest'
+            bioc: 'devel'
+            distro: mkl
+            origin: rhub
 
     # Trigger steps
     steps:

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -58,8 +58,7 @@ jobs:
             origin: rhub
           - distro_tag: 'latest'
             bioc: 'devel'
-            # https://hub.docker.com/r/rhub/gcc13
-            distro: gcc13
+            distro: fedora-gcc-devel
             origin: rhub
           - distro_tag: 'latest'
             bioc: '3.19'

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -36,37 +36,21 @@ jobs:
     strategy:
       matrix:
         image:
-          - distro_tag: '4.4.0'
-            bioc: '3.19'
-            distro: rstudio-local
-            origin: rocker
-          - distro_tag: '4.4.0'
-            bioc: '3.19'
-            distro: rstudio
-            origin: rocker
+          # - distro_tag: '4.4.0'
+          #   bioc: '3.19'
+          #   distro: rstudio-local
+          #   origin: rocker
+          # - distro_tag: '4.4.0'
+          #   bioc: '3.19'
+          #   distro: rstudio
+          #   origin: rocker
           - distro_tag: 'latest'
             bioc: 'devel'
-            distro: debian-clang-devel
-            origin: rhub
-          - distro_tag: 'latest'
-            bioc: 'devel'
-            distro: debian-gcc-devel
+            distro: gcc13
             origin: rhub
           - distro_tag: 'latest'
             bioc: 'devel'
-            distro: fedora-clang-devel
-            origin: rhub
-          - distro_tag: 'latest'
-            bioc: 'devel'
-            distro: fedora-gcc-devel
-            origin: rhub
-          - distro_tag: 'latest'
-            bioc: '3.19'
-            distro: debian-gcc-patched
-            origin: rhub
-          - distro_tag: 'latest'
-            bioc: '3.19'
-            distro: debian-gcc-release
+            distro: gcc14
             origin: rhub
 
     # Trigger steps

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -58,7 +58,8 @@ jobs:
             origin: rhub
           - distro_tag: 'latest'
             bioc: 'devel'
-            distro: fedora-gcc-devel
+            # https://hub.docker.com/r/rhub/gcc13
+            distro: gcc13
             origin: rhub
           - distro_tag: 'latest'
             bioc: '3.19'

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,21 +36,21 @@ COPY --chmod=0755 [\
 RUN ./install_sysdeps.sh ${DISTRIBUTION}
 
 # Install R packages
-RUN ./install_cran_pkgs.R ${DISTRIBUTION} && \
-    ./install_bioc.R ${BIOC_VERSION} && \
-    ./install_bioc_pkgs.R ${DISTRIBUTION} && \
-    ./install_gh_pkgs.R ${DISTRIBUTION} && \
-    ./install_other_pkgs.R ${DISTRIBUTION} && \
-    ./install_pip_pkgs.py ${DISTRIBUTION} && \
-    ./test_installations.sh && \
-    rm -f install_sysdeps.sh \
-        install_cran_pkgs.R \
-        install_bioc.R \
-        install_bioc_pkgs.R \
-        install_gh_pkgs.R \
-        install_other_pkgs.R \
-        install_pip_pkgs.py \
-        test_installations.sh
+RUN ./install_cran_pkgs.R ${DISTRIBUTION}
+RUN ./install_bioc.R ${BIOC_VERSION}
+RUN ./install_bioc_pkgs.R ${DISTRIBUTION}
+RUN ./install_gh_pkgs.R ${DISTRIBUTION}
+RUN ./install_other_pkgs.R ${DISTRIBUTION}
+RUN ./install_pip_pkgs.py ${DISTRIBUTION}
+    # ./test_installations.sh && \
+    # rm -f install_sysdeps.sh \
+    #     install_cran_pkgs.R \
+    #     install_bioc.R \
+    #     install_bioc_pkgs.R \
+    #     install_gh_pkgs.R \
+    #     install_other_pkgs.R \
+    #     install_pip_pkgs.py \
+    #     test_installations.sh
 
 # Run RStudio
 CMD ["/init"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,21 +32,24 @@ COPY --chmod=0755 [\
     "./"\
 ]
 
-# In order to have predictable results from TinyTex installer, set the CTAN mirror.
-# This variable is used by https://raw.githubusercontent.com/yihui/tinytex/master/tools/install-unx.sh.
+# In order to have predictable results from TinyTex installer, set a reliable CTAN mirror.
+# This variable is used by:
+# https://yihui.org/gh/tinytex/tools/install-base.sh
+# which is in turn used by:
+# https://raw.githubusercontent.com/yihui/tinytex/master/tools/install-unx.sh.
 ENV CTAN_REPO https://mirrors.mit.edu/CTAN/systems/texlive/tlnet
 
 # Install sysdeps
 RUN ./install_sysdeps.sh ${DISTRIBUTION}
 
 # Install R packages
-RUN ./install_cran_pkgs.R ${DISTRIBUTION}
-RUN ./install_bioc.R ${BIOC_VERSION}
-RUN ./install_bioc_pkgs.R ${DISTRIBUTION}
-RUN ./install_gh_pkgs.R ${DISTRIBUTION}
-RUN ./install_other_pkgs.R ${DISTRIBUTION}
-RUN ./install_pip_pkgs.py ${DISTRIBUTION}
-RUN ./test_installations.sh && \
+RUN ./install_cran_pkgs.R ${DISTRIBUTION} && \
+    ./install_bioc.R ${BIOC_VERSION} && \
+    ./install_bioc_pkgs.R ${DISTRIBUTION} && \
+    ./install_gh_pkgs.R ${DISTRIBUTION} && \
+    ./install_other_pkgs.R ${DISTRIBUTION} && \
+    ./install_pip_pkgs.py ${DISTRIBUTION} && \
+    ./test_installations.sh && \
     rm -f install_sysdeps.sh \
         install_cran_pkgs.R \
         install_bioc.R \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,17 +32,21 @@ COPY --chmod=0755 [\
     "./"\
 ]
 
+# In order to have predictable results from TinyTex installer, set the CTAN mirror.
+# This variable is used by https://raw.githubusercontent.com/yihui/tinytex/master/tools/install-unx.sh.
+ENV CTAN_REPO https://mirrors.mit.edu/CTAN/systems/texlive/tlnet
+
 # Install sysdeps
 RUN ./install_sysdeps.sh ${DISTRIBUTION}
 
 # Install R packages
-RUN ./install_cran_pkgs.R ${DISTRIBUTION} && \
-    ./install_bioc.R ${BIOC_VERSION} && \
-    ./install_bioc_pkgs.R ${DISTRIBUTION} && \
-    ./install_gh_pkgs.R ${DISTRIBUTION} && \
-    ./install_other_pkgs.R ${DISTRIBUTION} && \
-    ./install_pip_pkgs.py ${DISTRIBUTION} && \
-    ./test_installations.sh && \
+RUN ./install_cran_pkgs.R ${DISTRIBUTION}
+RUN ./install_bioc.R ${BIOC_VERSION}
+RUN ./install_bioc_pkgs.R ${DISTRIBUTION}
+RUN ./install_gh_pkgs.R ${DISTRIBUTION}
+RUN ./install_other_pkgs.R ${DISTRIBUTION}
+RUN ./install_pip_pkgs.py ${DISTRIBUTION}
+RUN ./test_installations.sh && \
     rm -f install_sysdeps.sh \
         install_cran_pkgs.R \
         install_bioc.R \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN ./install_bioc_pkgs.R ${DISTRIBUTION}
 RUN ./install_gh_pkgs.R ${DISTRIBUTION}
 RUN ./install_other_pkgs.R ${DISTRIBUTION}
 RUN ./install_pip_pkgs.py ${DISTRIBUTION}
-    # ./test_installations.sh && \
+RUN ./test_installations.sh
     # rm -f install_sysdeps.sh \
     #     install_cran_pkgs.R \
     #     install_bioc.R \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,21 +36,21 @@ COPY --chmod=0755 [\
 RUN ./install_sysdeps.sh ${DISTRIBUTION}
 
 # Install R packages
-RUN ./install_cran_pkgs.R ${DISTRIBUTION}
-RUN ./install_bioc.R ${BIOC_VERSION}
-RUN ./install_bioc_pkgs.R ${DISTRIBUTION}
-RUN ./install_gh_pkgs.R ${DISTRIBUTION}
-RUN ./install_other_pkgs.R ${DISTRIBUTION}
-RUN ./install_pip_pkgs.py ${DISTRIBUTION}
-RUN ./test_installations.sh
-    # rm -f install_sysdeps.sh \
-    #     install_cran_pkgs.R \
-    #     install_bioc.R \
-    #     install_bioc_pkgs.R \
-    #     install_gh_pkgs.R \
-    #     install_other_pkgs.R \
-    #     install_pip_pkgs.py \
-    #     test_installations.sh
+RUN ./install_cran_pkgs.R ${DISTRIBUTION} && \
+    ./install_bioc.R ${BIOC_VERSION} && \
+    ./install_bioc_pkgs.R ${DISTRIBUTION} && \
+    ./install_gh_pkgs.R ${DISTRIBUTION} && \
+    ./install_other_pkgs.R ${DISTRIBUTION} && \
+    ./install_pip_pkgs.py ${DISTRIBUTION} && \
+    ./test_installations.sh && \
+    rm -f install_sysdeps.sh \
+        install_cran_pkgs.R \
+        install_bioc.R \
+        install_bioc_pkgs.R \
+        install_gh_pkgs.R \
+        install_other_pkgs.R \
+        install_pip_pkgs.py \
+        test_installations.sh
 
 # Run RStudio
 CMD ["/init"]

--- a/scripts/install_bioc_pkgs.R
+++ b/scripts/install_bioc_pkgs.R
@@ -44,6 +44,13 @@ new_pkgs <- bioc_pkgs[[distribution]][
   !(bioc_pkgs[[distribution]] %in% installed.packages()[, "Package"])
 ]
 
+install.packages(
+  "cmdstanr",
+  repos='https://stan-dev.r-universe.dev'
+)
+
+cmdstanr::install_cmdstan()
+
 # Install only uninstalled packages
 if (length(new_pkgs)) {
   BiocManager::install(new_pkgs,

--- a/scripts/install_bioc_pkgs.R
+++ b/scripts/install_bioc_pkgs.R
@@ -30,12 +30,8 @@ shared_pkgs <- c(
 bioc_pkgs <- list(
   rstudio = shared_pkgs,
   `rstudio-local` = shared_pkgs,
-  `debian-clang-devel` = shared_pkgs,
-  `debian-gcc-devel` = shared_pkgs,
-  `fedora-clang-devel` = shared_pkgs,
-  `fedora-gcc-devel` = shared_pkgs,
-  `debian-gcc-patched` = shared_pkgs,
-  `debian-gcc-release` = shared_pkgs
+  `gcc13` = shared_pkgs,
+  `gcc14` = shared_pkgs
 )
 
 # Get diff of installed and uninstalled packages for
@@ -44,6 +40,7 @@ new_pkgs <- bioc_pkgs[[distribution]][
   !(bioc_pkgs[[distribution]] %in% installed.packages()[, "Package"])
 ]
 
+# cmdstanr is available on r-universe.dev.
 install.packages(
   "cmdstanr",
   repos='https://stan-dev.r-universe.dev'

--- a/scripts/install_bioc_pkgs.R
+++ b/scripts/install_bioc_pkgs.R
@@ -31,7 +31,12 @@ bioc_pkgs <- list(
   rstudio = shared_pkgs,
   `rstudio-local` = shared_pkgs,
   `gcc13` = shared_pkgs,
-  `gcc14` = shared_pkgs
+  `gcc14` = shared_pkgs,
+  `atlas` = shared_pkgs,
+  `valgrind` = shared_pkgs,
+  `intel` = shared_pkgs,
+  `nosuggests` = shared_pkgs,
+  `mkl` = shared_pkgs
 )
 
 # Get diff of installed and uninstalled packages for

--- a/scripts/install_cran_pkgs.R
+++ b/scripts/install_cran_pkgs.R
@@ -266,7 +266,7 @@ if (length(new_pkgs_from_src)) {
 }
 
 # Install rjags with special params for fedora distros
-if (startsWith(distribution, "fedora") || startsWith(distribution, "gcc")) {
+if (startsWith(distribution, "gcc")) {
   install.packages(
     "rjags",
     type = "source",

--- a/scripts/install_cran_pkgs.R
+++ b/scripts/install_cran_pkgs.R
@@ -240,7 +240,12 @@ cran_pkgs <- list(
     local_dev_packages
   ),
   `gcc13` = shared_pkgs[!shared_pkgs %in% c("rjags")],
-  `gcc14` = shared_pkgs[!shared_pkgs %in% c("rjags")]
+  `gcc14` = shared_pkgs[!shared_pkgs %in% c("rjags")],
+  `atlas` = shared_pkgs[!shared_pkgs %in% c("rjags")],
+  `valgrind` = shared_pkgs[!shared_pkgs %in% c("rjags")],
+  `intel` = shared_pkgs[!shared_pkgs %in% c("rjags")],
+  `nosuggests` = shared_pkgs[!shared_pkgs %in% c("rjags")],
+  `mkl` = shared_pkgs[!shared_pkgs %in% c("rjags")]
 )
 
 # Re-install packages with newer versions
@@ -266,7 +271,7 @@ if (length(new_pkgs_from_src)) {
 }
 
 # Install rjags with special params for fedora distros
-if (startsWith(distribution, "gcc")) {
+if (startsWith(distribution, "gcc") || distribution == "atlas" || distribution == "valgrind" || distribution == "intel" || distribution == "nosuggests" || distribution == "mkl") {
   install.packages(
     "rjags",
     type = "source",

--- a/scripts/install_cran_pkgs.R
+++ b/scripts/install_cran_pkgs.R
@@ -243,6 +243,7 @@ cran_pkgs <- list(
   `debian-gcc-devel` = shared_pkgs,
   `fedora-clang-devel` = shared_pkgs[!shared_pkgs %in% c("rjags")],
   `fedora-gcc-devel` = shared_pkgs[!shared_pkgs %in% c("rjags")],
+  `gcc13` = shared_pkgs[!shared_pkgs %in% c("rjags")],
   `debian-gcc-patched` = shared_pkgs,
   `debian-gcc-release` = shared_pkgs
 )
@@ -270,7 +271,7 @@ if (length(new_pkgs_from_src)) {
 }
 
 # Install rjags with special params for fedora distros
-if (startsWith(distribution, "fedora")) {
+if (startsWith(distribution, "fedora") || startsWith(distribution, "gcc13")) {
   install.packages(
     "rjags",
     type = "source",

--- a/scripts/install_cran_pkgs.R
+++ b/scripts/install_cran_pkgs.R
@@ -239,13 +239,8 @@ cran_pkgs <- list(
     pharmaverse_pkgs,
     local_dev_packages
   ),
-  `debian-clang-devel` = shared_pkgs,
-  `debian-gcc-devel` = shared_pkgs,
-  `fedora-clang-devel` = shared_pkgs[!shared_pkgs %in% c("rjags")],
-  `fedora-gcc-devel` = shared_pkgs[!shared_pkgs %in% c("rjags")],
   `gcc13` = shared_pkgs[!shared_pkgs %in% c("rjags")],
-  `debian-gcc-patched` = shared_pkgs,
-  `debian-gcc-release` = shared_pkgs
+  `gcc14` = shared_pkgs[!shared_pkgs %in% c("rjags")]
 )
 
 # Re-install packages with newer versions
@@ -271,7 +266,7 @@ if (length(new_pkgs_from_src)) {
 }
 
 # Install rjags with special params for fedora distros
-if (startsWith(distribution, "fedora") || startsWith(distribution, "gcc13")) {
+if (startsWith(distribution, "fedora") || startsWith(distribution, "gcc")) {
   install.packages(
     "rjags",
     type = "source",

--- a/scripts/install_gh_pkgs.R
+++ b/scripts/install_gh_pkgs.R
@@ -18,7 +18,12 @@ gh_pkgs <- list(
   rstudio = shared_pkgs,
   `rstudio-local` = shared_pkgs,
   `gcc13` = shared_pkgs,
-  `gcc14` = shared_pkgs
+  `gcc14` = shared_pkgs,
+  `atlas` = shared_pkgs,
+  `valgrind` = shared_pkgs,
+  `intel` = shared_pkgs,
+  `nosuggests` = shared_pkgs,
+  `mkl` = shared_pkgs
 )
 
 # Get diff of installed and uninstalled packages for

--- a/scripts/install_gh_pkgs.R
+++ b/scripts/install_gh_pkgs.R
@@ -17,12 +17,8 @@ shared_pkgs <- c(
 gh_pkgs <- list(
   rstudio = shared_pkgs,
   `rstudio-local` = shared_pkgs,
-  `debian-clang-devel` = shared_pkgs,
-  `debian-gcc-devel` = shared_pkgs,
-  `fedora-clang-devel` = shared_pkgs,
-  `fedora-gcc-devel` = shared_pkgs,
-  `debian-gcc-patched` = shared_pkgs,
-  `debian-gcc-release` = shared_pkgs
+  `gcc13` = shared_pkgs,
+  `gcc14` = shared_pkgs
 )
 
 # Get diff of installed and uninstalled packages for

--- a/scripts/install_other_pkgs.R
+++ b/scripts/install_other_pkgs.R
@@ -33,7 +33,12 @@ other_pkgs <- list(
     stat_pkgs
   ),
   `gcc13` = c(stat_pkgs),
-  `gcc14` = c(stat_pkgs)
+  `gcc14` = c(stat_pkgs),
+  `atlas` = c(stat_pkgs),
+  `valgrind` = c(stat_pkgs),
+  `intel` = c(stat_pkgs),
+  `nosuggests` = c(stat_pkgs),
+  `mkl` = c(stat_pkgs)
 )
 
 # Get diff of installed and uninstalled packages for

--- a/scripts/install_other_pkgs.R
+++ b/scripts/install_other_pkgs.R
@@ -32,12 +32,8 @@ other_pkgs <- list(
     pharmaverse_packages,
     stat_pkgs
   ),
-  `debian-clang-devel` = c(stat_pkgs),
-  `debian-gcc-devel` = c(stat_pkgs),
-  `fedora-clang-devel` = c(stat_pkgs),
-  `fedora-gcc-devel` = c(stat_pkgs),
-  `debian-gcc-patched` = c(stat_pkgs),
-  `debian-gcc-release` = c(stat_pkgs)
+  `gcc13` = c(stat_pkgs),
+  `gcc14` = c(stat_pkgs)
 )
 
 # Get diff of installed and uninstalled packages for

--- a/scripts/install_pip_pkgs.py
+++ b/scripts/install_pip_pkgs.py
@@ -31,12 +31,8 @@ pip_packages = {
     + [
         "pre-commit",
     ],
-    "debian-clang-devel": [],
-    "debian-gcc-devel": [],
-    "fedora-clang-devel": [],
-    "fedora-gcc-devel": [],
-    "debian-gcc-patched": [],
-    "debian-gcc-release": [],
+    "gcc13": [],
+    "gcc14": [],
 }
 
 # Install packages

--- a/scripts/install_pip_pkgs.py
+++ b/scripts/install_pip_pkgs.py
@@ -33,6 +33,11 @@ pip_packages = {
     ],
     "gcc13": [],
     "gcc14": [],
+    "atlas": [],
+    "valgrind": [],
+    "intel": [],
+    "nosuggests": [],
+    "mkl": [],
 }
 
 # Install packages

--- a/scripts/install_sysdeps.sh
+++ b/scripts/install_sysdeps.sh
@@ -190,7 +190,7 @@ then {
 }
 fi
 
-if [[ "$distribution" =~ ^fedora.* ]]
+if [[ "$distribution" =~ ^fedora.*|^gcc.* ]]
 then {
     # Update
     dnf update -y

--- a/scripts/install_sysdeps.sh
+++ b/scripts/install_sysdeps.sh
@@ -115,6 +115,11 @@ nano \
 # Deps specific to the gcc rhub image.
 pkgs_to_install_fedora["gcc13"]="${shared_deps_fedora}"
 pkgs_to_install_fedora["gcc14"]="${shared_deps_fedora}"
+pkgs_to_install_fedora["atlas"]="${shared_deps_fedora}"
+pkgs_to_install_fedora["valgrind"]="${shared_deps_fedora}"
+pkgs_to_install_fedora["intel"]="${shared_deps_fedora}"
+pkgs_to_install_fedora["nosuggests"]="${shared_deps_fedora}"
+pkgs_to_install_fedora["mkl"]="${shared_deps_fedora}"
 
 # Perform installations for debian distros
 if [[ "$distribution" =~ ^rstudio.* ]]
@@ -168,7 +173,7 @@ then {
 }
 fi
 
-if [[ "$distribution" =~ ^gcc.* ]]
+if [[ "$distribution" =~ ^gcc.*|^atlas$|^valgrind$|^intel$|^nosuggests$|^mkl$ ]]
 then {
     # Update
     dnf update -y

--- a/scripts/install_sysdeps.sh
+++ b/scripts/install_sysdeps.sh
@@ -117,7 +117,7 @@ pkgs_to_install_fedora["gcc13"]="${shared_deps_fedora}"
 pkgs_to_install_fedora["gcc14"]="${shared_deps_fedora}"
 
 # Perform installations for debian distros
-if [[ "$distribution" =~ ^rstudio.*|^debian.* ]]
+if [[ "$distribution" =~ ^rstudio.* ]]
 then {
     # Set env vars
     export DEBIAN_FRONTEND=noninteractive

--- a/scripts/install_sysdeps.sh
+++ b/scripts/install_sysdeps.sh
@@ -112,7 +112,7 @@ less \
 nano \
 "
 
-# Deps specific to the gcc rhub image.
+# Deps specific to the Fedora-based rhub image.
 pkgs_to_install_fedora["gcc13"]="${shared_deps_fedora}"
 pkgs_to_install_fedora["gcc14"]="${shared_deps_fedora}"
 pkgs_to_install_fedora["atlas"]="${shared_deps_fedora}"

--- a/scripts/install_sysdeps.sh
+++ b/scripts/install_sysdeps.sh
@@ -138,6 +138,9 @@ pkgs_to_install_fedora["fedora-gcc-devel"]="${shared_deps_fedora}"
 # Deps specific on the fedora-clang-devel image
 pkgs_to_install_fedora["fedora-clang-devel"]="${shared_deps_fedora}"
 
+# Deps specific to the gcc rhub image.
+pkgs_to_install_fedora["gcc13"]="${shared_deps_fedora}"
+
 # Perform installations for debian distros
 if [[ "$distribution" =~ ^rstudio.*|^debian.* ]]
 then {

--- a/scripts/install_sysdeps.sh
+++ b/scripts/install_sysdeps.sh
@@ -112,34 +112,9 @@ less \
 nano \
 "
 
-# Deps specific on the debian-clang-devel image
-pkgs_to_install_debian["debian-clang-devel"]="${shared_deps_debian} \
-jags \
-"
-
-# Deps specific on the debian-gcc-devel image
-pkgs_to_install_debian["debian-gcc-devel"]="${shared_deps_debian} \
-jags \
-"
-
-# Deps specific on the debian-gcc-patched image
-pkgs_to_install_debian["debian-gcc-patched"]="${shared_deps_debian} \
-jags \
-"
-
-# Deps specific on the debian-gcc-release image
-pkgs_to_install_debian["debian-gcc-release"]="${shared_deps_debian} \
-jags \
-"
-
-# Deps specific on the fedora-gcc-devel image
-pkgs_to_install_fedora["fedora-gcc-devel"]="${shared_deps_fedora}"
-
-# Deps specific on the fedora-clang-devel image
-pkgs_to_install_fedora["fedora-clang-devel"]="${shared_deps_fedora}"
-
 # Deps specific to the gcc rhub image.
 pkgs_to_install_fedora["gcc13"]="${shared_deps_fedora}"
+pkgs_to_install_fedora["gcc14"]="${shared_deps_fedora}"
 
 # Perform installations for debian distros
 if [[ "$distribution" =~ ^rstudio.*|^debian.* ]]
@@ -193,7 +168,7 @@ then {
 }
 fi
 
-if [[ "$distribution" =~ ^fedora.*|^gcc.* ]]
+if [[ "$distribution" =~ ^gcc.* ]]
 then {
     # Update
     dnf update -y


### PR DESCRIPTION
Change rhub Fedora images to new Fedora-based images called `gcc13` and `gcc14`.
Also remove outdated `debian` rhub images.

Closes https://github.com/insightsengineering/ci-images/issues/88.