### PR TITLE
Fix failing image builds

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -263,7 +263,8 @@ jobs:
         with:
           context: ./
           file: Dockerfile
-          push: ${{ steps.build_vars.outputs.DOCKER_PUSH }}
+          push: false
+          # push: ${{ steps.build_vars.outputs.DOCKER_PUSH }}
           tags: ${{ steps.build_vars.outputs.FULL_NAMES }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -263,8 +263,7 @@ jobs:
         with:
           context: ./
           file: Dockerfile
-          push: false
-          # push: ${{ steps.build_vars.outputs.DOCKER_PUSH }}
+          push: ${{ steps.build_vars.outputs.DOCKER_PUSH }}
           tags: ${{ steps.build_vars.outputs.FULL_NAMES }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/scripts/install_gh_pkgs.R
+++ b/scripts/install_gh_pkgs.R
@@ -9,7 +9,7 @@ distribution <- args[1]
 # Regular CRAN packages to install
 shared_pkgs <- c(
   "insightsengineering/nesttemplate",
-  "openpharma/staged.dependencies@*release",
+  "openpharma/staged.dependencies@*release"
 )
 
 gh_pkgs <- list(
@@ -33,6 +33,7 @@ new_pkgs <- gh_pkgs[[distribution]][
 # Install only uninstalled packages
 if (length(new_pkgs)) {
   devtools::install_github(
-    new_pkgs
+    new_pkgs,
+    upgrade = "never"
   )
 }

--- a/scripts/install_gh_pkgs.R
+++ b/scripts/install_gh_pkgs.R
@@ -33,7 +33,6 @@ new_pkgs <- gh_pkgs[[distribution]][
 # Install only uninstalled packages
 if (length(new_pkgs)) {
   devtools::install_github(
-    new_pkgs,
-    upgrade = "never"
+    new_pkgs
   )
 }

--- a/scripts/install_pip_pkgs.py
+++ b/scripts/install_pip_pkgs.py
@@ -18,7 +18,7 @@ def install(packages=[]):
         packages (list(str)): List of package names
     """
     if len(packages) > 0:
-        subprocess.check_call(["pip3", "install", " ".join(packages)])
+        subprocess.check_call(["pip3", "install", "--break-system-packages", " ".join(packages)])
 
 
 # Shared packages across distributions

--- a/scripts/install_sysdeps.sh
+++ b/scripts/install_sysdeps.sh
@@ -37,6 +37,7 @@ libsodium-dev \
 default-jdk \
 cmake \
 graphviz \
+libaio1t64 \
 alien \
 libxss1 \
 git \

--- a/scripts/install_sysdeps.sh
+++ b/scripts/install_sysdeps.sh
@@ -37,7 +37,6 @@ libsodium-dev \
 default-jdk \
 cmake \
 graphviz \
-libaio1 \
 alien \
 libxss1 \
 git \


### PR DESCRIPTION
This PR addresses the following problems:

* A package name changed from `libaio1` to `libaio1t64` in Ubuntu 24.04.
* A trailing comma in the list of GitHub packages to install was causing this error:
    ```
    Error in c("insightsengineering/nesttemplate", "openpharma/staged.dependencies@*release",  : 
      argument 3 is empty
    Execution halted
    ```
* Installation of `pre-commit` pip package in rstudio-local image failed because of a missing `--break-system-packages` flag.