### PR TITLE
chore: R 4.6.1 + BioC 3.23, harden TinyTeX install

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,7 +40,7 @@ on:
           R version (also used as the tag to pull the origin image).
         required: true
         type: choice
-        default: "4.5.2"
+        default: "4.6.1"
         options:
           - "4.1.0"
           - "4.1.1"
@@ -58,6 +58,7 @@ on:
           - "4.4.2"
           - "4.5.0"
           - "4.5.2"
+          - "4.6.1"
           - "latest"
       latest_r_version:
         description: |
@@ -65,12 +66,12 @@ on:
           (Only relevant for rocker images).
         required: false
         type: string
-        default: "4.5.2"
+        default: "4.6.1"
       bioc_version:
         description: BioConductor Release
         required: true
         type: choice
-        default: "3.22"
+        default: "3.23"
         options:
           - "3.13"
           - "3.14"
@@ -82,6 +83,7 @@ on:
           - "3.20"
           - "3.21"
           - "3.22"
+          - "3.23"
           - "devel"
       latest_bioc_version:
         description: |
@@ -89,7 +91,7 @@ on:
           (Only relevant for rocker images).
         required: false
         type: string
-        default: "3.22"
+        default: "3.23"
       tag:
         description: |
           Custom Image Tag/Version. Defaults to current date in the `YYYY.MM.DD` format if unspecified.

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -36,42 +36,44 @@ jobs:
     strategy:
       matrix:
         image:
-          - distro_tag: '4.5.2'
-            bioc: '3.22'
+          - distro_tag: '4.6.1'
+            bioc: '3.23'
             distro: rstudio-local
             origin: rocker
-          - distro_tag: '4.5.2'
-            bioc: '3.22'
+          - distro_tag: '4.6.1'
+            bioc: '3.23'
             distro: rstudio
             origin: rocker
-          - distro_tag: 'latest'
-            bioc: 'devel'
-            distro: gcc13
-            origin: rhub
-          - distro_tag: 'latest'
-            bioc: 'devel'
-            distro: gcc14
-            origin: rhub
-          - distro_tag: 'latest'
-            bioc: 'devel'
-            distro: atlas
-            origin: rhub
-          - distro_tag: 'latest'
-            bioc: 'devel'
-            distro: valgrind
-            origin: rhub
-          - distro_tag: 'latest'
-            bioc: 'devel'
-            distro: intel
-            origin: rhub
-          - distro_tag: 'latest'
-            bioc: 'devel'
-            distro: nosuggests
-            origin: rhub
-          - distro_tag: 'latest'
-            bioc: 'devel'
-            distro: mkl
-            origin: rhub
+          # TODO: the rhub-based images are temporarily disabled while their
+          # builds are failing. Re-enable once they build again.
+          # - distro_tag: 'latest'
+          #   bioc: 'devel'
+          #   distro: gcc13
+          #   origin: rhub
+          # - distro_tag: 'latest'
+          #   bioc: 'devel'
+          #   distro: gcc14
+          #   origin: rhub
+          # - distro_tag: 'latest'
+          #   bioc: 'devel'
+          #   distro: atlas
+          #   origin: rhub
+          # - distro_tag: 'latest'
+          #   bioc: 'devel'
+          #   distro: valgrind
+          #   origin: rhub
+          # - distro_tag: 'latest'
+          #   bioc: 'devel'
+          #   distro: intel
+          #   origin: rhub
+          # - distro_tag: 'latest'
+          #   bioc: 'devel'
+          #   distro: nosuggests
+          #   origin: rhub
+          # - distro_tag: 'latest'
+          #   bioc: 'devel'
+          #   distro: mkl
+          #   origin: rhub
 
     # Trigger steps
     steps:
@@ -91,8 +93,8 @@ jobs:
               "distribution": "${{ matrix.image.distro }}",
               "r_version": "${{ matrix.image.distro_tag }}",
               "bioc_version": "${{ matrix.image.bioc }}",
-              "latest_r_version": "4.5.2",
-              "latest_bioc_version": "3.22",
+              "latest_r_version": "4.6.1",
+              "latest_bioc_version": "3.23",
               "tag": "",
               "tag_latest": "true",
               "release_tag": "${{ needs.create-release.outputs.release_tag }}"

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         image:
-          - r: '4.5.2'
-            bioc: '3.22'
+          - r: '4.6.1'
+            bioc: '3.23'
             distro: rstudio
     steps:
       - name: Log in to the Container registry 🗝

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 # Build arguments
 ARG ORIGIN=rocker
 ARG ORIGIN_DISTRIBUTION=rstudio
-ARG R_VERSION=4.5.2
+ARG R_VERSION=4.6.1
 
 # Fetch base image
 FROM ${ORIGIN}/${ORIGIN_DISTRIBUTION}:${R_VERSION}
 
 # Reset args in build context
 ARG DISTRIBUTION=rstudio-local
-ARG BIOC_VERSION=3.22
+ARG BIOC_VERSION=3.23
 
 # Set image metadata
 LABEL org.opencontainers.image.licenses="GPL-2.0-or-later" \
@@ -32,12 +32,20 @@ COPY --chmod=0755 [\
     "./"\
 ]
 
-# In order to have predictable results from TinyTex installer, set a reliable CTAN mirror.
+# In order to have predictable results from the TinyTeX installer, pin a single
+# TeX Live repository. It must be a single host rather than the mirror.ctan.org
+# redirector: the repository is contacted several times during the install (base
+# install, `tlmgr option repository`, then `tlmgr install`), and the redirector
+# hands out differently-synced mirrors per request, which causes tlmgr cross
+# release errors.
+# We use TinyTeX's own tlnet mirror, which is the installer's default, is
+# kept in sync for TinyTeX specifically, and is CDN-backed rather than a
+# single host.
 # This variable is used by:
-# https://yihui.org/gh/tinytex/tools/install-base.sh
+# https://tinytex.yihui.org/install-base.sh
 # which is in turn used by:
 # https://raw.githubusercontent.com/yihui/tinytex/master/tools/install-unx.sh.
-ENV CTAN_REPO https://mirrors.mit.edu/CTAN/systems/texlive/tlnet
+ENV CTAN_REPO https://tlnet.yihui.org
 
 # Install sysdeps
 RUN ./install_sysdeps.sh ${DISTRIBUTION}

--- a/scripts/install_cran_pkgs.R
+++ b/scripts/install_cran_pkgs.R
@@ -348,7 +348,14 @@ if (require("tinytex")) {
   # nolint start
   # See point 5 in
   # https://github.com/rbind/yihui/blob/master/content/tinytex/faq.md
+  # `set -e` stops the script at the first failing step. Without it the exit
+  # status is that of the last command, so a failed base install followed by a
+  # successful `tlmgr path add` would look like success and leave the image with
+  # a partial TinyTeX. The leading `rm -rf` makes the script idempotent so it
+  # can be retried: otherwise `mv` nests a second install in /opt/TinyTeX.
   tinytex_installer <- paste0('
+set -e
+rm -rf /opt/TinyTeX ~/.TinyTeX
 wget -qO- "https://raw.githubusercontent.com/yihui/tinytex/master/tools/install-unx.sh" | sh -s - --admin --no-path
 mv ~/.TinyTeX /opt/TinyTeX
 /opt/TinyTeX/bin/*/tlmgr path add
@@ -356,8 +363,23 @@ tlmgr install ', paste(tlmgr_packages, collapse = " "), "
 tlmgr path add
 ")
   # nolint end
-  exit_status <- system(tinytex_installer)
-  cat("TinyTeX installer exited with code =", exit_status, "\n")
+  # The installer pulls from a single remote repository, so a transient
+  # network failure can abort a build that is already an hour in. Retry
+  # a few times before giving up.
+  max_attempts <- 3
+  for (attempt in seq_len(max_attempts)) {
+    exit_status <- system(tinytex_installer)
+    cat(
+      "TinyTeX installer attempt", attempt, "of", max_attempts,
+      "exited with code =", exit_status, "\n"
+    )
+    if (exit_status == 0) {
+      break
+    }
+    if (attempt < max_attempts) {
+      Sys.sleep(30)
+    }
+  }
   if (exit_status != 0) {
     quit(status = exit_status)
   }


### PR DESCRIPTION
### Description

  Bumps R 4.5.2 → 4.6.1 and BioC 3.22 → 3.23 (BioC 3.23 requires R 4.6, so they
  move together). Base OS is unchanged, so no sysdeps churn expected.

  Also:

  - **Temporarily disables the rhub images** in the scheduled matrix. Over the
    last 11 runs `atlas`/`gcc13`/`gcc14`/`intel`/`nosuggests` are 0/11 and
    `mkl`/`valgrind` ~40%, from a libcurl include-path issue unrelated to this
    bump. Still available via manual dispatch.
  - **Replaces the hardcoded `mirrors.mit.edu` CTAN mirror** with TinyTeX's own
    tlnet mirror — byte-identical `texlive.tlpdb`, CDN-backed. MIT had an outage
    that failed the 2026-08-05 `rstudio` build. Not the `mirror.ctan.org`
    redirector: it hands back differently-synced mirrors per request, which
    causes tlmgr cross-release errors.
  - **Adds `set -e` + retry to the TinyTeX install.** The exit status previously
    came from the last command, so a failed install could report success and
    ship a partial TinyTeX.